### PR TITLE
Updated version # button and rest of footer to color match site

### DIFF
--- a/BucStop/Views/Shared/_Layout.cshtml
+++ b/BucStop/Views/Shared/_Layout.cshtml
@@ -47,7 +47,7 @@
    
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2023 - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/chrisseals98/BOBBY/releases/tag/v2.0.0">Version: 2.0.0</a>
+            &copy; 2023 - BucStop - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a> - <a href="https://github.com/chrisseals98/BOBBY/releases/tag/v2.0.0" style="color:#C6AA76;">Version: 2.0.0</a>
 
         </div>
     </footer>

--- a/BucStop/wwwroot/css/site.css
+++ b/BucStop/wwwroot/css/site.css
@@ -48,6 +48,10 @@ p {
     color: white;
 }
 
+div {
+    color: #C6AA76;
+}
+
 /* Color and font classes */
 .color-etsu-navy {
     color: #00053E;

--- a/BucStop/wwwroot/css/site.css
+++ b/BucStop/wwwroot/css/site.css
@@ -48,10 +48,6 @@ p {
     color: white;
 }
 
-div {
-    color: #C6AA76;
-}
-
 /* Color and font classes */
 .color-etsu-navy {
     color: #00053E;


### PR DESCRIPTION
Got the version number button to be the same color as the privacy button is was next to. Also got the copyright BucStop to be the same color, it was gray before.